### PR TITLE
Add `Encoding` literal type

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -30,8 +30,10 @@ function fromHexString(hex: string): Uint8Array {
   return buf;
 }
 
+export type Encoding = "utf8" | "utf-8" | "base64" | "hex" | "hexadecimal";
+
 /** Decodes a Uint8Array to utf8-, base64-, or hex-encoded string. */
-export function decode(buf: Uint8Array, encoding: string = "utf8"): string {
+export function decode(buf: Uint8Array, encoding: Encoding = "utf8"): string {
   if (/^utf-?8$/i.test(encoding)) {
     return decoder.decode(buf);
   } else if (/^base64$/i.test(encoding)) {
@@ -43,7 +45,7 @@ export function decode(buf: Uint8Array, encoding: string = "utf8"): string {
   }
 }
 
-export function encode(str: string, encoding: string = "utf8"): Uint8Array {
+export function encode(str: string, encoding: Encoding = "utf8"): Uint8Array {
   if (/^utf-?8$/i.test(encoding)) {
     return encoder.encode(str);
   } else if (/^base64$/i.test(encoding)) {


### PR DESCRIPTION
This PR adds a new type `Encoding`, which is the set of possible string literals that are valid as an encoding argument for `decode` or `encode`.

This allows, for example, autocompletion of encoding (VSCode, with the Deno extension):
![std-encoding-autocomplete](https://user-images.githubusercontent.com/7883508/81624506-f06c0580-93bb-11ea-992f-a31bb633003a.png)

and static detection of invalid encodings at compile time:
![std-encoding-errors](https://user-images.githubusercontent.com/7883508/81624514-f530b980-93bb-11ea-99d9-4cfca2e4f2e3.png)

